### PR TITLE
add rollup cjs bundle

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -4,8 +4,8 @@ const defaultToken = encryption.uniqueString();
 const [hostname, httpPort, udpPort] = ['0.0.0.0', 8965, 8966];
 
 const announce = [
-    'http://prs-bp2.press.one:8965/announce',
-    // 'http://localhost:8965/announce',
+    // 'http://prs-bp2.press.one:8965/announce',
+    'http://127.0.0.1:8965/announce',
 ];
 
 const localAnnounce = announce.map(url => `${url}/${defaultToken}`);

--- a/lib/torrent.mjs
+++ b/lib/torrent.mjs
@@ -30,18 +30,7 @@ const suffix = 'torrent';
 // @TODO by @Leaskh: A bug related to webtorrent, this api will remove all jobs.
 // const remove = (torrentId, opts) => _client && _client.remove(torrentId, opts);
 
-// Version number in Azureus-style. Generated from major and minor semver version.
-// For example: '0.16.1' -> '0016', '1.2.5' -> '0102'...
-const VERSION_STR = (await utilitas.which()).version
-    .replace(/\d*./g, v => `0${v % 100}`.slice(-2)).slice(0, 4);
-
-// Version prefix string (used in peer ID). WebTorrent uses the Azureus-style
-// encoding: '-', two characters for client id ('WW'), four ascii digits for version
-// number, '-', followed by random numbers.
-// For example: '-RM0102-'...
-const VERSION_PREFIX = `-RM${VERSION_STR}-`;
-
-let _client, _timer, _callback;
+let _client, _timer, _callback, VERSION_STR;
 
 // https://github.com/webtorrent/create-torrent
 // OPTIONS:
@@ -78,9 +67,24 @@ const createTorrentFile = async (content, options) => {
     );
 };
 
-const createPeerId = () => arr2hex(text2arr(
-    VERSION_PREFIX + arr2base(randombytes(9))
-));
+const createPeerId = async () => {
+    if (!VERSION_STR) {
+        // Version number in Azureus-style. Generated from major and minor semver version.
+        // For example: '0.16.1' -> '0016', '1.2.5' -> '0102'...
+        VERSION_STR = (await utilitas.which()).version
+            .replace(/\d*./g, v => `0${v % 100}`.slice(-2)).slice(0, 4);
+    }
+
+    // Version prefix string (used in peer ID). WebTorrent uses the Azureus-style
+    // encoding: '-', two characters for client id ('WW'), four ascii digits for version
+    // number, '-', followed by random numbers.
+    // For example: '-RM0102-'...
+    const VERSION_PREFIX = `-RM${VERSION_STR}-`;
+
+    return arr2hex(text2arr(
+        VERSION_PREFIX + arr2base(randombytes(9))
+    ));
+}
 
 const getStreamingAddress = (subPath) =>
     `http://localhost:${_client._server.server.address().port}${pathname}`
@@ -88,7 +92,7 @@ const getStreamingAddress = (subPath) =>
 
 const getClient = async (options) => {
     if (!_client) {
-        const peerId = options?.peerId || createPeerId();
+        const peerId = options?.peerId || await createPeerId();
         _client = new webTorrent({
             // maxConns: Number,                   // Max number of connections per torrent (default=55)
             // nodeId: String | Buffer,            // DHT protocol node ID (default=randomly generated)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "private": false,
     "homepage": "https://github.com/rumsystem/rum-torrent",
     "main": "index.mjs",
+    "exports": {
+        "import": "./index.mjs",
+        "require": "./dist/index.cjs"
+    },
     "test": "test.mjs",
     "type": "module",
     "bin": {
@@ -38,5 +42,11 @@
         "prettier-bytes": "^1.0.4",
         "utilitas": "^1992.2.2",
         "webtorrent": "github:Leask/webtorrent"
+    },
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "rollup": "^3.18.0"
     }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,53 @@
+import { join } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import commonjs from '@rollup/plugin-commonjs';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import json from '@rollup/plugin-json';
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+    input: 'index.mjs',
+    output: {
+        file: 'dist/index.cjs',
+        inlineDynamicImports: true,
+        format: 'cjs',
+    },
+    external: [
+        '@waylaidwanderer/chatgpt-api',
+        'node-gyp-build',
+        'utp-native',
+    ],
+    plugins: [
+        commonjs(),
+        nodeResolve({ preferBuiltins: true }),
+        json(),
+        {
+            name: 'bundle-content-replacement',
+            writeBundle: async () => {
+                const filePath = join(process.cwd(), 'dist/index.cjs');
+                let output = (await readFile(filePath)).toString();
+                // node_modules/xml2js/lib/xml2js.js:47
+                output = output.replace(
+                    "ValidationError.name = 'ValidationError';",
+                    "",
+                );
+                // node_modules/xml2js/lib/xml2js.js:61
+                output = output.replace(
+                    "Parser.name = 'Parser';",
+                    "",
+                );
+                // node_modules/cross-fetch-ponyfill/browser.js:10
+                output = output.replace(
+                    "self.fetch || (() => { throw new Error('global fetch is not available!') });",
+                    "global.fetch || (() => { throw new Error('global fetch is not available!') });",
+                );
+                // node_modules/uint8-util/browser.js:51
+                output = output.replace(
+                    "const scope = typeof window !== 'undefined' ? window : self;",
+                    "const scope = typeof window !== 'undefined' ? window : global;",
+                );
+                await writeFile(filePath, output);
+            },
+        },
+    ],
+};


### PR DESCRIPTION
- 移除 top level await
- 使用 rollup 打包成 cjs

执行 `rollup -c` 就会打包输出到 `dist/index.cjs` 了。

一些说明：
- `package.json` 添加了 `exports` 字段，可以同时支持 `esm` 和 `cjs` 两种格式。

- 在使用 rollup 打包的时候发现 `utp-native` 和 `node-gyp-build` 包含 native 的 bin，所以得排除在外。

- 最后还对打包的结果做了一些修改（在 `rollup.config.mjs` 里）
`node_modules/xml2js/lib/xml2js.js:47`
`node_modules/xml2js/lib/xml2js.js:61`
这两个地方在执行时会出现报错提示 cannot change readonly property name。应该无影响所以就直接删掉了<br>
`node_modules/cross-fetch-ponyfill/browser.js:10`
`node_modules/uint8-util/browser.js:51`
这两个地方用到了 `self`，在 `node` 环境下报错，替换成了 `global`.

- 还有一个需要修改的是 `utilitas`，需要去除 top level await，rollup 没法把 top level await 转成 cjs 格式。应该有这几个地方需要修改
https://github.com/Leask/utilitas/blob/f695deff629d93206b9ea9e9f02bb0b433512624/lib/utilitas.mjs#L7
https://github.com/Leask/utilitas/blob/f695deff629d93206b9ea9e9f02bb0b433512624/lib/horizon.mjs#L22
https://github.com/Leask/utilitas/blob/f695deff629d93206b9ea9e9f02bb0b433512624/index.mjs#L45


<details>
<summary>这是我对 <code>utilitas</code> 临时的修改</summary>

```diff
diff --git a/index.mjs b/index.mjs
index 80b3fab..d266da6 100644
--- a/index.mjs
+++ b/index.mjs
@@ -38,10 +38,12 @@ export {
 if (utilitas.inBrowser() && !globalThis.utilitas) {
     globalThis.utilitas = {
         color, encryption, event, manifest, math, shekel, shot, storage, uoid,
         utilitas, uuid,
     };
-    utilitas.log(
-        `(${manifest.homepage}) is ready!`,
-        `${(await utilitas.which(manifest)).title}.*`
-    );
+    (async () => {
+        utilitas.log(
+            `(${manifest.homepage}) is ready!`,
+            `${(await utilitas.which(manifest)).title}.*`
+        );
+    })
 }
diff --git a/lib/horizon.mjs b/lib/horizon.mjs
index 40799c7..2d766ad 100644
--- a/lib/horizon.mjs
+++ b/lib/horizon.mjs
@@ -17,11 +17,11 @@ if (!globalThis.assert) {
     };
     for (let i in _assert || {}) { assert[i] = _assert[i]; }
 }

 // Buffer
-globalThis.Buffer = globalThis.Buffer || (await import('buffer/index.js')).Buffer;
+// globalThis.Buffer = globalThis.Buffer || (await import('buffer/index.js')).Buffer;

 // Is
 const _is = (type, value) => value?.constructor === type;
 const _type = (any) => typeof any === 'undefined' ? 'Undefined'
     : Object.prototype.toString.call(any).replace(/^\[[^\ ]*\ (.*)\]$/, '$1');
diff --git a/lib/utilitas.mjs b/lib/utilitas.mjs
index 0135b2b..e563477 100644
--- a/lib/utilitas.mjs
+++ b/lib/utilitas.mjs
@@ -1,13 +1,12 @@
 import { assertPath, readJson, } from './storage.mjs';
 import { basename as _basename, dirname, join, sep } from 'path';
 import { promisify } from 'util';
 import { validate as verifyUuid } from 'uuid';
+import { fileURLToPath } from 'url';
 import color from './color.mjs';

-const fileURLToPath = (await import('url')).fileURLToPath
-    || (url => new URL('', url).pathname);
 const call = (f, ...a) => promisify(Array.isArray(f) ? f[0].bind(f[1]) : f)(...a);
 const invalidTime = 'Invalid time.';
 const inBrowser = () => { try { return window; } catch (e) { } };
 const getDateByUnixTimestamp = (timestamp) => new Date(~~timestamp * 1000);
 const getUnixTimestampByDate = (date) => Math.round(date.getTime() / 1000);
```

</details>

我的测试结果是，从 electron 主进程可以直接把 `rum-torrent` require 进来使用。暂未发现报错和功能异常